### PR TITLE
Updated bignumber.js to version 2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "should": "5.2.0"
   },
   "dependencies": {
-    "bignumber.js": "2.0.7",
+    "bignumber.js": "2.0.8",
     "lodash.identity": "3.0.0"
   }
 }


### PR DESCRIPTION
:rocket:

bignumber.js just published version 2.0.8, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 8 commits (ahead by 8, behind by 1).
- [f549554](https://github.com/MikeMcl/bignumber.js/commit/f549554c8ca0c6ba9e3db40f366edc9422afc862): Update changelog
- [94a4418](https://github.com/MikeMcl/bignumber.js/commit/94a44180d50466c633a72cccdd12363880b984be): v2.0.8
- [c843791](https://github.com/MikeMcl/bignumber.js/commit/c8437914a7db7c962c079935af848145d19f545a): Internal round function bugfix
- [6bb22d9](https://github.com/MikeMcl/bignumber.js/commit/6bb22d94f7ba89e836ca1b228c825fde49ac5469): Merge pull request #71 from pbakondy/master
- [e335786](https://github.com/MikeMcl/bignumber.js/commit/e335786b3136abedbd1ef3d550edf1b416e1456a): add missing parentheses
- [4e21964](https://github.com/MikeMcl/bignumber.js/commit/4e21964fc8fa58b99d9ae4d9f7748ba573343581): Merge pull request #63 from droppedoncaprica/master
- [c6770d7](https://github.com/MikeMcl/bignumber.js/commit/c6770d7743fec89b9d056df7b6cbe7eebb264c17): Fix README's location of JS map.
- [3661d1c](https://github.com/MikeMcl/bignumber.js/commit/3661d1caf389955e52ae93d4f451a8c5e7dc3c2d): v2.0.7

See the [full diff](https://github.com/MikeMcl/bignumber.js/compare/968471891943735593f3711d2f6d9ce6f72868d1...f549554c8ca0c6ba9e3db40f366edc9422afc862).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
